### PR TITLE
feat: cleanup workflow, add GithubActionsTestLogger

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-latest]
+        os: [windows-latest]
     steps:
     - uses: actions/checkout@v4
     - name: Setup .NET

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,13 +11,25 @@ defaults:
     shell: pwsh
 
 jobs:
+  automerge:
+    runs-on: ubuntu-latest
+
+    permissions:
+      pull-requests: write
+      contents: write
+
+    steps:
+      - uses: fastify/github-action-merge-dependabot@v3.9.1
+        with:
+          use-github-auto-merge: true
+
   build-and-test:
     name: build-and-test on ${{matrix.os}}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest]
+        os: [windows-latest, ubuntu-latest]
     steps:
     - uses: actions/checkout@v4
     - name: Setup .NET
@@ -26,20 +38,22 @@ jobs:
         dotnet-version: | 
             3.1.x
             6.x
+    - name: Setup Dependency Caching
+      uses: actions/cache@v3
+      id: nuget-cache
+      with:
+        path: |
+          ~/.nuget/packages
+          ${{ github.workspace }}/**/obj/project.assets.json
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
+          ${{ runner.os }}-nuget-
+
     - name: Restore dependencies
       run: dotnet restore
     - name: Build
       run: dotnet build -p:ContinuousIntegrationBuild=True --no-restore --configuration Release
     - name: Test
-      run: dotnet test --no-build --configuration Release --verbosity normal
-
-  automerge:
-    needs: [build-and-test]
-    runs-on: ubuntu-latest
-
-    permissions:
-      pull-requests: write
-      contents: write
-
-    steps:
-      - uses: fastify/github-action-merge-dependabot@v3.9.1  
+      run: dotnet test --no-build --configuration Release --verbosity normal --logger GitHubActions --
+        RunConfiguration.CollectSourceInformation=true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,18 @@ jobs:
         dotnet-version: | 
             3.1.x
             6.x
+    - name: Setup Dependency Caching
+      uses: actions/cache@v3
+      id: nuget-cache
+      with:
+        path: |
+          ~/.nuget/packages
+          ${{ github.workspace }}/**/obj/project.assets.json
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
+          ${{ runner.os }}-nuget-
+
     - name: Restore dependencies
       run: dotnet restore
     - name: Set Version

--- a/ListingManager.Tests/EssentialCSharp.ListingManager.Tests.csproj
+++ b/ListingManager.Tests/EssentialCSharp.ListingManager.Tests.csproj
@@ -11,6 +11,10 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="GitHubActionsTestLogger" Version="2.3.3">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
         <PackageReference Include="IntelliTect.TestTools.Console" Version="1.0.0-CI-20181030-214503" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
         <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />

--- a/ListingManager.Tests/FileManagerTests.cs
+++ b/ListingManager.Tests/FileManagerTests.cs
@@ -11,6 +11,6 @@ public class FileManagerTests
     [DataRow("asdasdsad/asd/asd/asd/Chapter42", 42)]
     public void GetChapterNumber(string chapterFilePath, int expectedChapterNum)
     {
-        Assert.AreEqual(expectedChapterNum, FileManager.GetFolderChapterNumber(chapterFilePath));
+        Assert.AreNotEqual(expectedChapterNum, FileManager.GetFolderChapterNumber(chapterFilePath));
     }
 }

--- a/ListingManager.Tests/FileManagerTests.cs
+++ b/ListingManager.Tests/FileManagerTests.cs
@@ -11,6 +11,6 @@ public class FileManagerTests
     [DataRow("asdasdsad/asd/asd/asd/Chapter42", 42)]
     public void GetChapterNumber(string chapterFilePath, int expectedChapterNum)
     {
-        Assert.AreNotEqual(expectedChapterNum, FileManager.GetFolderChapterNumber(chapterFilePath));
+        Assert.AreEqual(expectedChapterNum, FileManager.GetFolderChapterNumber(chapterFilePath));
     }
 }


### PR DESCRIPTION
Shows test failures more clearly in a PR.

Ex:
![image](https://github.com/IntelliTect/EssentialCSharp.ListingManager/assets/22186029/3e8cf3ef-83d8-4f5d-99c9-7a44ea9adccc)

![image](https://github.com/IntelliTect/EssentialCSharp.ListingManager/assets/22186029/5e662122-5c7d-48e8-adf9-a35dd6090f2a)

Source code: https://github.com/Tyrrrz/GitHubActionsTestLogger
